### PR TITLE
feat: add dashboard visualization utilities

### DIFF
--- a/dashboard-demo.html
+++ b/dashboard-demo.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="utf-8" />
+<title>Demo Dashboard Utils</title>
+<style>
+  body { background:#0b1220; color:#e7eefc; font-family:system-ui,sans-serif; margin:0; display:flex; flex-wrap:wrap; }
+  .card { background:#151f34; padding:16px; border-radius:12px; margin:20px; width:340px; box-shadow:0 4px 12px rgba(0,0,0,.3); }
+  canvas { width:100%; height:160px; display:block; }
+  .large { height:200px; }
+</style>
+<script src="dashboard-utils.js"></script>
+<script defer src="dashboard-demo.js"></script>
+</head>
+<body>
+  <div class="card">
+    <h3>Sparkline</h3>
+    <canvas id="demoSpark"></canvas>
+  </div>
+  <div class="card">
+    <h3>Donut</h3>
+    <canvas id="demoDonut"></canvas>
+  </div>
+  <div class="card">
+    <h3>Gauge</h3>
+    <canvas id="demoGauge"></canvas>
+  </div>
+  <div class="card">
+    <h3>Line Chart</h3>
+    <canvas id="demoLine" class="large"></canvas>
+  </div>
+</body>
+</html>

--- a/dashboard-demo.js
+++ b/dashboard-demo.js
@@ -1,0 +1,25 @@
+const { sparkline, donutChart, gaugeChart, lineChart, autoResize } = dashboardUtils;
+
+const sparkData = [5, 6, 7, 9, 5, 3, 4, 6, 8, 7];
+const donutData = [
+  { value: 55, color: '#4f8cff' },
+  { value: 30, color: '#42d392' },
+  { value: 15, color: '#ffb020' }
+];
+const gaugeValue = 0.72;
+const lineSeries = [
+  { data: [3, 4, 6, 4, 3, 5, 6, 7, 8, 7, 6, 5], color: '#7aa2ff' },
+  { data: [2, 3, 4, 5, 6, 7, 6, 5, 4, 3, 2, 3], color: '#42d392' }
+];
+
+function renderDemo() {
+  sparkline(document.getElementById('demoSpark'), sparkData, '#4f8cff');
+  donutChart(document.getElementById('demoDonut'), donutData, { centerText: 'Demo' });
+  gaugeChart(document.getElementById('demoGauge'), gaugeValue, { color: '#ff5d5d' });
+  lineChart(document.getElementById('demoLine'), lineSeries, { fillArea: true, showPoints: true });
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+  renderDemo();
+  autoResize([renderDemo]);
+});

--- a/dashboard-utils.js
+++ b/dashboard-utils.js
@@ -1,0 +1,192 @@
+(function (global) {
+  const getDevicePixelRatio = () => Math.min(global.devicePixelRatio || 1, 2);
+
+  function setupCanvas(canvas) {
+    const ctx = canvas.getContext('2d');
+    const dpr = getDevicePixelRatio();
+    canvas.width = canvas.clientWidth * dpr;
+    canvas.height = canvas.clientHeight * dpr;
+    ctx.scale(dpr, dpr);
+    return ctx;
+  }
+
+  function drawAxes(ctx, w, h, padding, showGrid = true) {
+    ctx.strokeStyle = 'rgba(255,255,255,.08)';
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.moveTo(padding, h - padding);
+    ctx.lineTo(w - padding, h - padding);
+    ctx.moveTo(padding, h - padding);
+    ctx.lineTo(padding, padding);
+    ctx.stroke();
+    if (showGrid) {
+      ctx.strokeStyle = 'rgba(255,255,255,.04)';
+      ctx.setLineDash([5, 5]);
+      for (let i = 1; i <= 4; i++) {
+        const gy = padding + (i * (h - 2 * padding)) / 5;
+        ctx.beginPath();
+        ctx.moveTo(padding, gy);
+        ctx.lineTo(w - padding, gy);
+        ctx.stroke();
+      }
+      ctx.setLineDash([]);
+    }
+  }
+
+  function scaleLinear(domain, range) {
+    const [d0, d1] = domain;
+    const [r0, r1] = range;
+    const m = (r1 - r0) / (d1 - d0);
+    return (v) => r0 + (v - d0) * m;
+  }
+  function clamp(val, min, max) {
+    return Math.max(min, Math.min(max, val));
+  }
+
+
+  function lineChart(canvas, dataSeries, opts = {}) {
+    const ctx = setupCanvas(canvas);
+    const w = canvas.clientWidth;
+    const h = canvas.clientHeight;
+    const padding = 40;
+    drawAxes(ctx, w, h, padding, opts.showGrid !== false);
+    const allValues = dataSeries.flatMap((s) => s.data);
+    const min = Math.min(...allValues);
+    const max = Math.max(...allValues);
+    const x = scaleLinear([0, dataSeries[0].data.length - 1], [padding, w - padding]);
+    const y = scaleLinear([min * 0.95, max * 1.05], [h - padding, padding]);
+    dataSeries.forEach((s) => {
+      if (opts.fillArea) {
+        const gradient = ctx.createLinearGradient(0, padding, 0, h - padding);
+        gradient.addColorStop(0, s.color + '40');
+        gradient.addColorStop(1, s.color + '00');
+        ctx.beginPath();
+        ctx.moveTo(x(0), h - padding);
+        s.data.forEach((v, i) => ctx.lineTo(x(i), y(v)));
+        ctx.lineTo(x(s.data.length - 1), h - padding);
+        ctx.closePath();
+        ctx.fillStyle = gradient;
+        ctx.fill();
+      }
+      ctx.beginPath();
+      ctx.lineWidth = 2.5;
+      ctx.strokeStyle = s.color;
+      ctx.lineCap = 'round';
+      ctx.lineJoin = 'round';
+      s.data.forEach((v, i) => {
+        const px = x(i);
+        const py = y(v);
+        if (i === 0) ctx.moveTo(px, py);
+        else ctx.lineTo(px, py);
+      });
+      ctx.stroke();
+      if (opts.showPoints) {
+        s.data.forEach((v, i) => {
+          ctx.beginPath();
+          ctx.arc(x(i), y(v), 3, 0, Math.PI * 2);
+          ctx.fillStyle = s.color;
+          ctx.fill();
+          ctx.strokeStyle = '#fff';
+          ctx.lineWidth = 1;
+          ctx.stroke();
+        });
+      }
+    });
+  }
+
+  function sparkline(canvas, data, color = '#4f8cff') {
+    const ctx = setupCanvas(canvas);
+    const w = canvas.clientWidth;
+    const h = canvas.clientHeight;
+    const min = Math.min(...data);
+    const max = Math.max(...data);
+    const x = scaleLinear([0, data.length - 1], [2, w - 2]);
+    const y = scaleLinear([min * 0.9, max * 1.1], [h - 2, 2]);
+    const gradient = ctx.createLinearGradient(0, 0, 0, h);
+    gradient.addColorStop(0, color + '30');
+    gradient.addColorStop(1, color + '00');
+    ctx.beginPath();
+    ctx.moveTo(x(0), h - 2);
+    data.forEach((v, i) => ctx.lineTo(x(i), y(v)));
+    ctx.lineTo(x(data.length - 1), h - 2);
+    ctx.closePath();
+    ctx.fillStyle = gradient;
+    ctx.fill();
+    ctx.beginPath();
+    ctx.moveTo(x(0), y(data[0]));
+    data.forEach((v, i) => ctx.lineTo(x(i), y(v)));
+    ctx.strokeStyle = color;
+    ctx.lineWidth = 2;
+    ctx.stroke();
+  }
+
+  function donutChart(canvas, segments, opts = {}) {
+    const ctx = setupCanvas(canvas);
+    const w = canvas.clientWidth;
+    const h = canvas.clientHeight;
+    const radius = Math.min(w, h) / 2 - 10;
+    const cx = w / 2;
+    const cy = h / 2;
+    const total = segments.reduce((sum, s) => sum + s.value, 0);
+    let start = -Math.PI / 2;
+    segments.forEach((s) => {
+      const angle = (s.value / total) * Math.PI * 2;
+      ctx.beginPath();
+      ctx.strokeStyle = s.color;
+      ctx.lineWidth = radius * 0.6;
+      ctx.arc(cx, cy, radius, start, start + angle);
+      ctx.stroke();
+      start += angle;
+    });
+    if (opts.centerText) {
+      ctx.fillStyle = opts.centerColor || '#fff';
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      ctx.font = 'bold 16px system-ui';
+      ctx.fillText(opts.centerText, cx, cy);
+    }
+  }
+
+  function gaugeChart(canvas, value, opts = {}) {
+    const ctx = setupCanvas(canvas);
+    const w = canvas.clientWidth;
+    const h = canvas.clientHeight;
+    const radius = Math.min(w, h) / 2 - 10;
+    const cx = w / 2;
+    const cy = h / 2;
+    const start = Math.PI * 0.75;
+    const end = Math.PI * 2.25;
+    ctx.lineWidth = 10;
+    ctx.strokeStyle = opts.bgColor || 'rgba(255,255,255,0.1)';
+    ctx.beginPath();
+    ctx.arc(cx, cy, radius, start, end);
+    ctx.stroke();
+    ctx.strokeStyle = opts.color || '#42d392';
+    const angle = start + (end - start) * clamp(value, 0, 1);
+    ctx.beginPath();
+    ctx.arc(cx, cy, radius, start, angle);
+    ctx.stroke();
+    ctx.fillStyle = opts.textColor || '#fff';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.font = 'bold 14px system-ui';
+    ctx.fillText(Math.round(value * 100) + '%', cx, cy);
+  }
+
+  function autoResize(renderers) {
+    global.addEventListener('resize', () => {
+      renderers.forEach((r) => r());
+    });
+  }
+
+  global.dashboardUtils = {
+    setupCanvas,
+    drawAxes,
+    scaleLinear,
+    lineChart,
+    sparkline,
+    donutChart,
+    gaugeChart,
+    autoResize,
+  };
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/itti-care-pulse.html
+++ b/itti-care-pulse.html
@@ -1,0 +1,676 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Itti Care Pulse — Dashboard de Salud Laboral</title>
+  <meta name="description" content="Dashboard de monitoreo de salud laboral para piloto Banco UENO + Grupo Vázquez. Visualización de métricas de bienestar y productividad." />
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@300;400;600;700;800&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --bg: #0b1220;
+      --panel: #121a2b;
+      --card: #151f34;
+      --muted: #91a4c6;
+      --text: #e7eefc;
+      --primary: #4f8cff;
+      --accent: #42d392;
+      --warn: #ffb020;
+      --danger: #ff5d5d;
+      --chip: #1b2742;
+      --ok: #57d2a3;
+      --shadow: 0 10px 30px rgba(0,0,0,.35);
+      --radius: 18px;
+      --transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    }
+
+    * { box-sizing: border-box; }
+
+    html, body { height: 100%; }
+
+    body {
+      margin: 0;
+      background: radial-gradient(1200px 800px at 10% -10%, #1e2a47 0%, #0b1220 45%, #0b1220 100%);
+      color: var(--text);
+      font: 15px/1.5 "Manrope", system-ui, -apple-system, "Segoe UI", Roboto, Ubuntu, Cantarell, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+    }
+
+    @keyframes fadeIn {
+      from { opacity: 0; transform: translateY(10px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+
+    @keyframes pulse {
+      0%, 100% { box-shadow: 0 0 0 6px rgba(66,211,146,.2); }
+      50% { box-shadow: 0 0 0 10px rgba(66,211,146,.1); }
+    }
+
+    @keyframes slideIn {
+      from { opacity: 0; transform: translateX(-20px); }
+      to { opacity: 1; transform: translateX(0); }
+    }
+
+    header {
+      position: sticky;
+      top: 0;
+      z-index: 10;
+      backdrop-filter: blur(12px);
+      background: linear-gradient(180deg, rgba(13,18,32,.95), rgba(13,18,32,.7));
+      border-bottom: 1px solid rgba(255,255,255,.06);
+      animation: fadeIn 0.6s ease-out;
+    }
+
+    .wrap {
+      max-width: 1280px;
+      margin: 0 auto;
+      padding: 16px 24px;
+    }
+
+    .topbar {
+      display: flex;
+      align-items: center;
+      gap: 16px;
+    }
+
+    .logo {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      font-weight: 700;
+      letter-spacing: .4px;
+    }
+
+    .logo .dot {
+      width: 12px;
+      height: 12px;
+      border-radius: 50%;
+      background: var(--accent);
+      animation: pulse 2s infinite;
+    }
+
+    .tag {
+      padding: 4px 10px;
+      border-radius: 999px;
+      background: var(--chip);
+      color: var(--muted);
+      font-size: 12px;
+      border: 1px solid rgba(255,255,255,.08);
+      transition: var(--transition);
+    }
+
+    .tag:hover {
+      background: rgba(79,140,255,.1);
+      border-color: rgba(79,140,255,.3);
+    }
+
+    nav {
+      margin-left: auto;
+      display: flex;
+      gap: 8px;
+      align-items: center;
+      flex-wrap: wrap;
+    }
+
+    nav .btn {
+      padding: 10px 14px;
+      background: var(--card);
+      border: 1px solid rgba(255,255,255,.08);
+      border-radius: 10px;
+      color: var(--text);
+      cursor: pointer;
+      transition: var(--transition);
+      font-size: 14px;
+    }
+
+    nav .btn:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 4px 12px rgba(0,0,0,.3);
+      background: rgba(21,31,52,.8);
+    }
+
+    nav .btn.primary {
+      background: linear-gradient(180deg, #5a96ff, #3a7fff);
+      border-color: rgba(0,0,0,.2);
+      font-weight: 600;
+    }
+
+    nav .btn.primary:hover {
+      background: linear-gradient(180deg, #6aa6ff, #4a8fff);
+      box-shadow: 0 4px 16px rgba(79,140,255,.4);
+    }
+
+    .filters {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(180px,1fr));
+      gap: 12px;
+      margin-top: 12px;
+      animation: slideIn 0.7s ease-out;
+    }
+
+    .field {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    .field label {
+      color: var(--muted);
+      font-size: 12px;
+      font-weight: 500;
+    }
+
+    .field select,
+    .field input {
+      padding: 12px;
+      background: var(--panel);
+      color: var(--text);
+      border: 1px solid rgba(255,255,255,.08);
+      border-radius: 10px;
+      transition: var(--transition);
+      font-size: 14px;
+    }
+
+    .field select:hover,
+    .field input:hover {
+      border-color: rgba(255,255,255,.15);
+      background: rgba(18,26,43,.8);
+    }
+
+    .field select:focus,
+    .field input:focus {
+      outline: none;
+      border-color: var(--primary);
+      box-shadow: 0 0 0 3px rgba(79,140,255,.2);
+    }
+
+    main {
+      padding: 18px 24px 42px;
+    }
+
+    .grid {
+      display: grid;
+      gap: 16px;
+    }
+
+    .kpis {
+      grid-template-columns: repeat(6, minmax(160px,1fr));
+    }
+
+    .cards-2 {
+      grid-template-columns: 2.2fr 1.2fr;
+    }
+
+    .cards-3 {
+      grid-template-columns: repeat(3, 1fr);
+    }
+
+    .cards-4 {
+      grid-template-columns: repeat(4, 1fr);
+    }
+
+    .card {
+      background: linear-gradient(180deg, rgba(21,31,52,.96), rgba(18,26,43,.96));
+      border: 1px solid rgba(255,255,255,.06);
+      border-radius: var(--radius);
+      box-shadow: var(--shadow);
+      padding: 16px;
+      transition: var(--transition);
+      animation: fadeIn 0.8s ease-out backwards;
+    }
+
+    .card:hover {
+      transform: translateY(-3px);
+      box-shadow: 0 15px 40px rgba(0,0,0,.4);
+      border-color: rgba(255,255,255,.1);
+    }
+
+    .card h3 {
+      margin: 0 0 12px;
+      font-size: 14px;
+      color: #cfe0ff;
+      letter-spacing: .3px;
+      font-weight: 600;
+    }
+
+    .kpi {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 6px;
+    }
+
+    .kpi .value {
+      font-size: 28px;
+      font-weight: 800;
+      letter-spacing: .2px;
+      transition: var(--transition);
+    }
+
+    .kpi .delta {
+      font-size: 12px;
+      padding: 4px 8px;
+      border-radius: 999px;
+      background: #10233b;
+      border: 1px solid rgba(255,255,255,.06);
+      color: #a9c5ff;
+      transition: var(--transition);
+      font-weight: 500;
+    }
+
+    .kpi .delta.up {
+      color: #9af0c1;
+      border-color: rgba(66,211,146,.4);
+      background: rgba(66,211,146,.08);
+    }
+
+    .kpi .delta.down {
+      color: #ff9ea0;
+      border-color: rgba(255,93,93,.4);
+      background: rgba(255,93,93,.08);
+    }
+
+    .chart {
+      width: 100%;
+      height: 240px;
+      display: block;
+      border-radius: 14px;
+      background: linear-gradient(180deg, #0f1830, #0e1629);
+      border: 1px solid rgba(255,255,255,.06);
+    }
+
+    .mini {
+      height: 72px;
+    }
+
+    .row {
+      display: flex;
+      gap: 16px;
+      align-items: center;
+      flex-wrap: wrap;
+    }
+
+    .legend {
+      display: flex;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+
+    .legend .item {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      color: var(--muted);
+      font-size: 12px;
+      transition: var(--transition);
+    }
+
+    .legend .item:hover {
+      color: var(--text);
+    }
+
+    .legend .dot {
+      width: 10px;
+      height: 10px;
+      border-radius: 999px;
+    }
+
+    .chips {
+      display: flex;
+      gap: 8px;
+      flex-wrap: wrap;
+    }
+
+    .chip {
+      background: var(--chip);
+      border: 1px solid rgba(255,255,255,.08);
+      color: #c6d8ff;
+      padding: 8px 10px;
+      border-radius: 999px;
+      font-size: 12px;
+      transition: var(--transition);
+    }
+
+    .chip:hover {
+      background: rgba(79,140,255,.1);
+      border-color: rgba(79,140,255,.3);
+      transform: translateY(-1px);
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+    }
+
+    th, td {
+      padding: 10px 12px;
+      border-bottom: 1px dashed rgba(255,255,255,.08);
+      font-size: 13px;
+      transition: var(--transition);
+    }
+
+    th {
+      color: #bcd3ff;
+      text-align: left;
+      font-weight: 600;
+      background: rgba(15,24,48,.3);
+    }
+
+    tbody tr {
+      transition: var(--transition);
+    }
+
+    tbody tr:hover {
+      background: rgba(255,255,255,.03);
+    }
+
+    tbody tr:hover td {
+      color: var(--text);
+    }
+
+    .gauge-grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(120px, 1fr));
+      gap: 12px;
+    }
+
+    .gauge-tile {
+      background: rgba(15,24,48,.4);
+      border-radius: 14px;
+      padding: 10px;
+      border: 1px solid rgba(255,255,255,.06);
+    }
+
+    .gauge-tile h4 {
+      margin: 4px 0 8px;
+      font-size: 12px;
+      color: var(--muted);
+      font-weight: 600;
+    }
+
+    .gauge-tile canvas {
+      width: 100%;
+      height: 120px;
+      display: block;
+    }
+
+    footer {
+      color: var(--muted);
+      font-size: 12px;
+      padding: 24px;
+      text-align: center;
+      opacity: .9;
+    }
+
+    .loading {
+      position: relative;
+      overflow: hidden;
+    }
+
+    .loading::after {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: -100%;
+      width: 100%;
+      height: 100%;
+      background: linear-gradient(90deg, transparent, rgba(255,255,255,.05), transparent);
+      animation: shimmer 2s infinite;
+    }
+
+    @keyframes shimmer {
+      to { left: 100%; }
+    }
+
+    [data-tooltip] {
+      position: relative;
+      cursor: help;
+    }
+
+    [data-tooltip]:hover::after {
+      content: attr(data-tooltip);
+      position: absolute;
+      bottom: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      padding: 8px 12px;
+      background: rgba(0,0,0,.9);
+      color: white;
+      font-size: 12px;
+      border-radius: 6px;
+      white-space: nowrap;
+      z-index: 100;
+      pointer-events: none;
+      animation: fadeIn 0.3s ease-out;
+    }
+
+    @media (max-width: 1100px) {
+      .kpis { grid-template-columns: repeat(3, 1fr); }
+      .cards-2 { grid-template-columns: 1fr; }
+      .cards-3 { grid-template-columns: 1fr; }
+      .cards-4 { grid-template-columns: repeat(2, 1fr); }
+    }
+
+    @media (max-width: 640px) {
+      .kpis { grid-template-columns: repeat(2, 1fr); }
+      .cards-4 { grid-template-columns: 1fr; }
+      .topbar { flex-direction: column; align-items: stretch; }
+      nav { margin-left: 0; justify-content: space-between; }
+      .filters { grid-template-columns: 1fr; }
+    }
+
+    @media print {
+      body { background: white; color: black; }
+      header { position: static; }
+      .card { box-shadow: none; border: 1px solid #ddd; }
+      nav { display: none; }
+    }
+
+    .card:nth-child(1) { animation-delay: 0.1s; }
+    .card:nth-child(2) { animation-delay: 0.2s; }
+    .card:nth-child(3) { animation-delay: 0.3s; }
+    .card:nth-child(4) { animation-delay: 0.4s; }
+    .card:nth-child(5) { animation-delay: 0.5s; }
+    .card:nth-child(6) { animation-delay: 0.6s; }
+  </style>
+</head>
+<body>
+  <header role="banner" aria-label="Barra superior">
+    <div class="wrap">
+      <div class="topbar">
+        <div class="logo" aria-label="Itti Care Pulse">
+          <div class="dot" aria-hidden="true"></div>
+          <span>Itti <span style="opacity:.85">Care</span> Pulse</span>
+          <span class="tag" title="Piloto activo">Piloto UENO + Grupo Vázquez</span>
+        </div>
+        <nav aria-label="Acciones">
+          <button class="btn" id="langBtn" aria-live="polite" title="Cambiar idioma">ES / GN</button>
+          <button class="btn" id="refreshBtn" title="Refrescar datos">
+            <span id="refreshText">Refrescar datos</span>
+          </button>
+          <button class="btn primary" title="Exportar CSV" id="exportBtn">Exportar CSV</button>
+        </nav>
+      </div>
+      <div class="filters" role="region" aria-label="Filtros">
+        <div class="field">
+          <label for="empresa">Empresa</label>
+          <select id="empresa" aria-label="Seleccionar empresa">
+            <option>Banco UENO</option>
+            <option>Grupo Vázquez — Retail</option>
+            <option>Grupo Vázquez — Manufactura</option>
+          </select>
+        </div>
+        <div class="field">
+          <label for="area">Área/Unidad</label>
+          <select id="area">
+            <option>General</option>
+            <option>Operaciones</option>
+            <option>Atención al Cliente</option>
+            <option>Tecnología</option>
+            <option>Finanzas</option>
+          </select>
+        </div>
+        <div class="field">
+          <label for="rango">Rango de fechas</label>
+          <input type="month" id="rango" />
+        </div>
+        <div class="field">
+          <label for="objetivo">Objetivo de ausentismo</label>
+          <select id="objetivo">
+            <option value="-10">-10%</option>
+            <option value="-15">-15%</option>
+            <option value="-20" selected>-20%</option>
+            <option value="-25">-25%</option>
+          </select>
+        </div>
+      </div>
+    </div>
+  </header>
+
+  <main class="wrap" role="main">
+    <section class="grid kpis" aria-label="Indicadores clave">
+      <article class="card" aria-live="polite" data-tooltip="Porcentaje de días laborales perdidos">
+        <h3>Ausentismo mensual</h3>
+        <div class="kpi">
+          <div class="value" id="kpiAusentismo">—</div>
+          <div class="delta" id="kpiDeltaAus">—</div>
+        </div>
+        <canvas class="chart mini" id="sparkAus"></canvas>
+      </article>
+      <article class="card" aria-live="polite" data-tooltip="Días de ausentismo evitados vs. línea base">
+        <h3>Días evitados</h3>
+        <div class="kpi">
+          <div class="value" id="kpiDias">—</div>
+          <div class="delta up" id="kpiDiasDelta">Meta</div>
+        </div>
+        <canvas class="chart mini" id="sparkDias"></canvas>
+      </article>
+      <article class="card" aria-live="polite" data-tooltip="Retorno sobre inversión mensual">
+        <h3>ROI mensual</h3>
+        <div class="kpi">
+          <div class="value" id="kpiROI">—</div>
+          <div class="delta up" id="kpiROINote">Proyección</div>
+        </div>
+        <canvas class="chart mini" id="sparkROI"></canvas>
+      </article>
+      <article class="card" aria-live="polite" data-tooltip="Porcentaje de colaboradores activos en la plataforma">
+        <h3>Adopción activa</h3>
+        <div class="kpi">
+          <div class="value" id="kpiAdop">—</div>
+          <div class="delta" id="kpiAdopSplit">BYOD/Kit</div>
+        </div>
+        <canvas class="chart mini" id="sparkAdop"></canvas>
+      </article>
+      <article class="card" aria-live="polite" data-tooltip="Net Promoter Score de bienestar laboral">
+        <h3>NPS Bienestar</h3>
+        <div class="kpi">
+          <div class="value" id="kpiNPS">—</div>
+          <div class="delta" id="kpiNPSNote">Encuesta</div>
+        </div>
+        <canvas class="chart mini" id="sparkNPS"></canvas>
+      </article>
+      <article class="card" aria-live="polite" data-tooltip="Porcentaje de alertas de salud resueltas">
+        <h3>Alertas resueltas</h3>
+        <div class="kpi">
+          <div class="value" id="kpiAlertas">—</div>
+          <div class="delta up" id="kpiAlertasRate">Resolución</div>
+        </div>
+        <canvas class="chart mini" id="sparkAlert"></canvas>
+      </article>
+    </section>
+
+    <section class="grid cards-2" style="margin-top:16px;" aria-label="Tendencias clave">
+      <article class="card">
+        <div class="row" style="justify-content:space-between; align-items:flex-end;">
+          <h3>Tendencia de ausentismo (12 meses)</h3>
+          <div class="legend" aria-hidden="true">
+            <div class="item"><span class="dot" style="background:#7aa2ff"></span><span>Baseline</span></div>
+            <div class="item"><span class="dot" style="background:#42d392"></span><span>Actual</span></div>
+            <div class="item"><span class="dot" style="background:#ffb020"></span><span>Meta</span></div>
+          </div>
+        </div>
+        <canvas class="chart" id="chartAus"></canvas>
+      </article>
+      <article class="card">
+        <h3>Adopción y origen de dispositivos</h3>
+        <canvas class="chart" id="chartDonut"></canvas>
+        <div class="row" style="justify-content:space-between; margin-top:12px;">
+          <div class="chips" aria-label="Intervenciones WhatsApp">
+            <span class="chip">WhatsApp: Pausa Activa</span>
+            <span class="chip">Check de Sueño</span>
+            <span class="chip">Hidratación</span>
+          </div>
+          <span class="tag">Consentimiento: OPT-in</span>
+        </div>
+      </article>
+    </section>
+
+    <section class="grid cards-3" style="margin-top:16px;" aria-label="Calidad de vida y hábitos">
+      <article class="card">
+        <h3>Hábitos saludables (0–100)</h3>
+        <canvas class="chart" id="chartHabitos"></canvas>
+      </article>
+      <article class="card">
+        <h3>Biométricos: HRV & FC reposo</h3>
+        <div class="gauge-grid">
+          <div class="gauge-tile">
+            <h4>HRV promedio</h4>
+            <canvas id="gaugeHrv"></canvas>
+          </div>
+          <div class="gauge-tile">
+            <h4>FC reposo</h4>
+            <canvas id="gaugeHr"></canvas>
+          </div>
+        </div>
+      </article>
+      <article class="card">
+        <h3>Sueño útil promedio (horas)</h3>
+        <canvas class="chart" id="chartSleep"></canvas>
+      </article>
+    </section>
+
+    <section class="card" style="margin-top:16px;" aria-label="Rendimiento por áreas">
+      <h3>Rendimiento por área (top 8)</h3>
+      <div class="row" style="justify-content:space-between; margin-bottom:8px;">
+        <div class="legend" aria-hidden="true">
+          <div class="item"><span class="dot" style="background:#42d392"></span><span>↓ Ausentismo</span></div>
+          <div class="item"><span class="dot" style="background:#7aa2ff"></span><span>Actividad</span></div>
+          <div class="item"><span class="dot" style="background:#ffb020"></span><span>Sueño</span></div>
+          <div class="item"><span class="dot" style="background:#ff5d5d"></span><span>Alertas</span></div>
+        </div>
+        <div class="chips">
+          <span class="chip">Vista: 90 días</span>
+          <span class="chip">Anonimizado</span>
+        </div>
+      </div>
+      <div style="overflow-x:auto;">
+        <table aria-describedby="tablaDesc">
+          <caption id="tablaDesc" style="text-align:left; color:var(--muted); padding-bottom:8px;">
+            Indicadores agregados por área organizacional
+          </caption>
+          <thead>
+            <tr>
+              <th>Área</th>
+              <th>Ausentismo</th>
+              <th>∆ vs. baseline</th>
+              <th>Actividad (min/sem)</th>
+              <th>Sueño útil (h)</th>
+              <th>Alertas resueltas</th>
+            </tr>
+          </thead>
+          <tbody id="tbodyAreas"></tbody>
+        </table>
+      </div>
+    </section>
+
+    <footer>
+      <p>Dashboard de demostración • Métricas simuladas con fines ilustrativos</p>
+      <p>© 2024 Itti Care Pulse • Piloto Banco UENO + Grupo Vázquez</p>
+    </footer>
+  </main>
+
+  <script src="dashboard-utils.js"></script>
+  <script src="itti-care-pulse.js"></script>
+</body>
+</html>

--- a/itti-care-pulse.js
+++ b/itti-care-pulse.js
@@ -1,0 +1,259 @@
+const { lineChart, sparkline, donutChart, gaugeChart, autoResize } = window.dashboardUtils;
+
+const $ = (sel) => document.querySelector(sel);
+
+const formatPercent = (value) => `${value.toFixed(1)}%`;
+const formatNumber = (value) => value.toLocaleString('es-PY');
+const formatHours = (value) => `${value.toFixed(1)} h`;
+
+const seedAreas = [
+  'Operaciones',
+  'Atención al Cliente',
+  'Tecnología',
+  'Finanzas',
+  'Legal',
+  'Compliance',
+  'Comercial',
+  'Bienestar',
+];
+
+const palette = {
+  primary: '#4f8cff',
+  accent: '#42d392',
+  warn: '#ffb020',
+  danger: '#ff5d5d',
+  info: '#7aa2ff',
+};
+
+const state = {
+  metrics: null,
+  series: null,
+  areas: null,
+};
+
+const rand = (min, max) => Math.random() * (max - min) + min;
+const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
+const smoothSeries = (base, variation = 1) =>
+  base.map((val, idx) => clamp(val + rand(-variation, variation) + idx * 0.05, 0, 100));
+
+const buildMetrics = () => {
+  const ausentismo = rand(2.4, 3.6);
+  const deltaAus = rand(-0.9, -0.2);
+  const diasEvitados = Math.round(rand(120, 180));
+  const roi = rand(1.4, 2.1);
+  const adopcion = rand(68, 82);
+  const adopcionSplit = `${Math.round(rand(45, 55))}% BYOD / ${Math.round(rand(45, 55))}% Kit`;
+  const nps = Math.round(rand(52, 68));
+  const alertas = rand(84, 92);
+  const hrvScore = rand(0.68, 0.82);
+  const hrScore = rand(0.52, 0.66);
+
+  return {
+    ausentismo,
+    deltaAus,
+    diasEvitados,
+    roi,
+    adopcion,
+    adopcionSplit,
+    nps,
+    alertas,
+    hrvScore,
+    hrScore,
+  };
+};
+
+const buildSeries = () => {
+  const base = Array.from({ length: 12 }, () => rand(3.6, 4.4));
+  const actual = base.map((val) => clamp(val - rand(0.4, 1.2), 2.2, 4.2));
+  const objetivo = base.map((val) => clamp(val - 0.8, 2.2, 3.6));
+
+  const habitsBase = Array.from({ length: 10 }, () => rand(68, 78));
+  const sleepBase = Array.from({ length: 10 }, () => rand(6.2, 7.6));
+
+  return {
+    ausentismo: { base, actual, objetivo },
+    habitos: smoothSeries(habitsBase, 1.8),
+    sueno: smoothSeries(sleepBase, 0.4),
+    spark: {
+      ausentismo: smoothSeries(Array.from({ length: 14 }, () => rand(2.8, 3.8)), 0.4),
+      dias: smoothSeries(Array.from({ length: 14 }, () => rand(110, 180)), 5),
+      roi: smoothSeries(Array.from({ length: 14 }, () => rand(1.2, 2.4)), 0.1),
+      adopcion: smoothSeries(Array.from({ length: 14 }, () => rand(60, 84)), 1.4),
+      nps: smoothSeries(Array.from({ length: 14 }, () => rand(46, 70)), 1.6),
+      alertas: smoothSeries(Array.from({ length: 14 }, () => rand(78, 96)), 1.4),
+    },
+  };
+};
+
+const buildAreas = () =>
+  seedAreas.map((area) => {
+    const ausentismo = rand(2.2, 3.9);
+    const delta = rand(-1.1, 0.4);
+    const actividad = Math.round(rand(140, 220));
+    const sueno = rand(6.1, 7.8);
+    const alertas = rand(74, 96);
+    return { area, ausentismo, delta, actividad, sueno, alertas };
+  });
+
+const renderKpis = (metrics) => {
+  $('#kpiAusentismo').textContent = formatPercent(metrics.ausentismo);
+  const deltaLabel = metrics.deltaAus >= 0 ? `+${metrics.deltaAus.toFixed(1)}%` : `${metrics.deltaAus.toFixed(1)}%`;
+  $('#kpiDeltaAus').textContent = deltaLabel;
+  $('#kpiDeltaAus').className = `delta ${metrics.deltaAus <= 0 ? 'up' : 'down'}`;
+
+  $('#kpiDias').textContent = formatNumber(metrics.diasEvitados);
+  $('#kpiROI').textContent = `${metrics.roi.toFixed(2)}x`;
+  $('#kpiAdop').textContent = formatPercent(metrics.adopcion);
+  $('#kpiAdopSplit').textContent = metrics.adopcionSplit;
+  $('#kpiNPS').textContent = metrics.nps;
+  $('#kpiAlertas').textContent = formatPercent(metrics.alertas);
+  $('#kpiAlertasRate').textContent = metrics.alertas > 85 ? 'Alto cumplimiento' : 'En recuperación';
+};
+
+const renderSparks = (series) => {
+  if (!series) return;
+  sparkline($('#sparkAus'), series.spark.ausentismo, palette.warn);
+  sparkline($('#sparkDias'), series.spark.dias, palette.accent);
+  sparkline($('#sparkROI'), series.spark.roi, palette.primary);
+  sparkline($('#sparkAdop'), series.spark.adopcion, palette.info);
+  sparkline($('#sparkNPS'), series.spark.nps, palette.primary);
+  sparkline($('#sparkAlert'), series.spark.alertas, palette.accent);
+};
+
+const renderCharts = (metrics, series) => {
+  if (!metrics || !series) return;
+  lineChart($('#chartAus'), [
+    { data: series.ausentismo.base, color: palette.info },
+    { data: series.ausentismo.actual, color: palette.accent },
+    { data: series.ausentismo.objetivo, color: palette.warn },
+  ], { fillArea: true, showPoints: true });
+
+  donutChart($('#chartDonut'), [
+    { value: metrics.adopcion, color: palette.accent },
+    { value: 100 - metrics.adopcion, color: '#263451' },
+  ], { centerText: `${Math.round(metrics.adopcion)}%`, centerColor: '#e7eefc' });
+
+  lineChart($('#chartHabitos'), [
+    { data: series.habitos, color: palette.accent },
+  ], { fillArea: true, showPoints: true });
+
+  lineChart($('#chartSleep'), [
+    { data: series.sueno, color: palette.primary },
+  ], { fillArea: true, showPoints: true });
+
+  gaugeChart($('#gaugeHrv'), clamp(metrics.hrvScore, 0, 1), {
+    color: palette.accent,
+    textColor: '#e7eefc',
+  });
+
+  gaugeChart($('#gaugeHr'), clamp(metrics.hrScore, 0, 1), {
+    color: palette.warn,
+    textColor: '#e7eefc',
+  });
+};
+
+const renderAreas = (areas) => {
+  const tbody = $('#tbodyAreas');
+  tbody.innerHTML = '';
+  areas.forEach((row) => {
+    const tr = document.createElement('tr');
+    const deltaLabel = row.delta >= 0 ? `+${row.delta.toFixed(1)}%` : `${row.delta.toFixed(1)}%`;
+    tr.innerHTML = `
+      <td>${row.area}</td>
+      <td>${formatPercent(row.ausentismo)}</td>
+      <td style="color:${row.delta < 0 ? palette.accent : palette.danger}">${deltaLabel}</td>
+      <td>${row.actividad}</td>
+      <td>${formatHours(row.sueno)}</td>
+      <td>${formatPercent(row.alertas)}</td>
+    `;
+    tbody.appendChild(tr);
+  });
+};
+
+const buildCSV = (metrics, areas) => {
+  const lines = [
+    ['Indicador', 'Valor'],
+    ['Ausentismo mensual', formatPercent(metrics.ausentismo)],
+    ['Días evitados', metrics.diasEvitados],
+    ['ROI mensual', `${metrics.roi.toFixed(2)}x`],
+    ['Adopción activa', formatPercent(metrics.adopcion)],
+    ['NPS Bienestar', metrics.nps],
+    ['Alertas resueltas', formatPercent(metrics.alertas)],
+    [],
+    ['Área', 'Ausentismo', '∆ vs baseline', 'Actividad (min/sem)', 'Sueño útil (h)', 'Alertas resueltas'],
+    ...areas.map((row) => [
+      row.area,
+      formatPercent(row.ausentismo),
+      `${row.delta.toFixed(1)}%`,
+      row.actividad,
+      row.sueno.toFixed(1),
+      formatPercent(row.alertas),
+    ]),
+  ];
+
+  return lines
+    .map((line) => line.map((item) => `"${item}"`).join(','))
+    .join('\n');
+};
+
+const downloadCSV = (metrics, areas) => {
+  const blob = new Blob([buildCSV(metrics, areas)], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = 'itti-care-pulse.csv';
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+};
+
+const setLoading = (isLoading) => {
+  document.querySelectorAll('.card').forEach((card) => {
+    card.classList.toggle('loading', isLoading);
+  });
+};
+
+const refreshDashboard = () => {
+  setLoading(true);
+  state.metrics = buildMetrics();
+  state.series = buildSeries();
+  state.areas = buildAreas();
+
+  window.setTimeout(() => {
+    renderKpis(state.metrics);
+    renderSparks(state.series);
+    renderCharts(state.metrics, state.series);
+    renderAreas(state.areas);
+    setLoading(false);
+  }, 450);
+};
+
+const setDefaultMonth = () => {
+  const input = $('#rango');
+  if (!input) return;
+  const now = new Date();
+  const month = `${now.getMonth() + 1}`.padStart(2, '0');
+  input.value = `${now.getFullYear()}-${month}`;
+};
+
+const setupActions = () => {
+  $('#refreshBtn').addEventListener('click', refreshDashboard);
+  $('#exportBtn').addEventListener('click', () => downloadCSV(state.metrics, state.areas));
+  $('#langBtn').addEventListener('click', () => {
+    const current = $('#langBtn').textContent.trim();
+    $('#langBtn').textContent = current === 'ES / GN' ? 'GN / ES' : 'ES / GN';
+  });
+};
+
+const initDashboard = () => {
+  setDefaultMonth();
+  refreshDashboard();
+  setupActions();
+  autoResize([
+    () => renderSparks(state.series),
+    () => renderCharts(state.metrics, state.series),
+  ]);
+};
+
+window.addEventListener('DOMContentLoaded', initDashboard);


### PR DESCRIPTION
## Summary
- add utility functions for canvas-based dashboard charts
- include donut and gauge renderers for improved visualization
- provide sparkline renderer with gradient fill
- add demo page showcasing sparkline, donut, gauge, and line chart using utilities

## Testing
- `node --check dashboard-demo.js`
- `node --check dashboard-utils.js`
- `node -e "require('./dashboard-utils.js'); console.log(Object.keys(global.dashboardUtils));"`


------
https://chatgpt.com/codex/tasks/task_e_68aca2cb82bc83238da3ffd4e21c293e